### PR TITLE
Upgrade to 1.0.10.1 with separate header and loader packages and UWP fix

### DIFF
--- a/samples/BasicXrApp/BasicXrApp_uwp.vcxproj
+++ b/samples/BasicXrApp/BasicXrApp_uwp.vcxproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -153,21 +154,24 @@
     <AppxManifest Include="Package.appxmanifest" Condition="'$(LinkCompiled)'!='false'">
       <SubType>Designer</SubType>
     </AppxManifest>
-    <None Include="TemporaryKey.pfx" />
     <None Include="packages.config" />
+    <None Include="TemporaryKey.pfx" />
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ImageContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\MeshContentTask.targets" />
     <Import Project="$(VSINSTALLDIR)\Common7\IDE\Extensions\Microsoft\VsGraphics\ShaderGraphContentTask.targets" />
-    <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" />
+    <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" />
+    <Import Project="..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props'))" />
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets'))" />
   </Target>
 </Project>

--- a/samples/BasicXrApp/BasicXrApp_win32.vcxproj
+++ b/samples/BasicXrApp/BasicXrApp_win32.vcxproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -113,13 +114,16 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" />
+    <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" />
+    <Import Project="..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props'))" />
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets'))" />
   </Target>
 </Project>

--- a/samples/BasicXrApp/packages.config
+++ b/samples/BasicXrApp/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenXR.Loader" version="1.0.10" targetFramework="native" />
+  <package id="OpenXR.Headers" version="1.0.10.1" targetFramework="native" />
+  <package id="OpenXR.Loader" version="1.0.10.1" targetFramework="native" />
 </packages>

--- a/samples/EyeGazeInteractionUwp/EyeGazeInteractionUwp.vcxproj
+++ b/samples/EyeGazeInteractionUwp/EyeGazeInteractionUwp.vcxproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -153,13 +154,16 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" />
+    <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" />
+    <Import Project="..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props'))" />
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets'))" />
   </Target>
 </Project>

--- a/samples/EyeGazeInteractionUwp/packages.config
+++ b/samples/EyeGazeInteractionUwp/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenXR.Loader" version="1.0.10" targetFramework="native" />
+  <package id="OpenXR.Headers" version="1.0.10.1" targetFramework="native" />
+  <package id="OpenXR.Loader" version="1.0.10.1" targetFramework="native" />
 </packages>

--- a/samples/SampleSceneUwp/SampleSceneUwp.vcxproj
+++ b/samples/SampleSceneUwp/SampleSceneUwp.vcxproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -152,13 +153,16 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" />
+    <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" />
+    <Import Project="..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props'))" />
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets'))" />
   </Target>
 </Project>

--- a/samples/SampleSceneUwp/packages.config
+++ b/samples/SampleSceneUwp/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenXR.Loader" version="1.0.10" targetFramework="native" />
+  <package id="OpenXR.Headers" version="1.0.10.1" targetFramework="native" />
+  <package id="OpenXR.Loader" version="1.0.10.1" targetFramework="native" />
 </packages>

--- a/samples/SampleSceneWin32/SampleSceneWin32.vcxproj
+++ b/samples/SampleSceneWin32/SampleSceneWin32.vcxproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
       <Configuration>Debug</Configuration>
@@ -117,13 +118,16 @@
     <Copy DestinationFolder="$(OutDir)" SkipUnchangedFiles="True" SourceFiles="@(ContentFiles)" UseHardlinksIfPossible="True" />
   </Target>
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" />
+    <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" />
+    <Import Project="..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props'))" />
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets'))" />
   </Target>
 </Project>

--- a/samples/SampleSceneWin32/packages.config
+++ b/samples/SampleSceneWin32/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenXR.Loader" version="1.0.10" targetFramework="native" />
+  <package id="OpenXR.Headers" version="1.0.10.1" targetFramework="native" />
+  <package id="OpenXR.Loader" version="1.0.10.1" targetFramework="native" />
 </packages>

--- a/samples/ThreeSpacesUwp/ThreeSpacesUwp.vcxproj
+++ b/samples/ThreeSpacesUwp/ThreeSpacesUwp.vcxproj
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -153,13 +154,16 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" />
+    <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" />
+    <Import Project="..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props'))" />
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10.1\build\native\OpenXR.Loader.targets'))" />
   </Target>
 </Project>

--- a/samples/ThreeSpacesUwp/packages.config
+++ b/samples/ThreeSpacesUwp/packages.config
@@ -1,4 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenXR.Loader" version="1.0.10" targetFramework="native" />
+  <package id="OpenXR.Headers" version="1.0.10.1" targetFramework="native" />
+  <package id="OpenXR.Loader" version="1.0.10.1" targetFramework="native" />
 </packages>

--- a/shared/SampleShared/SampleShared_uwp.vcxproj
+++ b/shared/SampleShared/SampleShared_uwp.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -382,13 +382,13 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" />
+    <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props'))" />
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets'))" />
   </Target>
 </Project>

--- a/shared/SampleShared/SampleShared_win32.vcxproj
+++ b/shared/SampleShared/SampleShared_win32.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -349,7 +349,7 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" />
+    <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" />
   </ImportGroup>
   <Target Name="AfterBuild">
     <Copy SourceFiles="Sample_SpecularHDR.dds" DestinationFolder="$(OutDir)" SkipUnchangedFiles="True" />
@@ -359,7 +359,7 @@
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props'))" />
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets'))" />
   </Target>
 </Project>

--- a/shared/SampleShared/packages.config
+++ b/shared/SampleShared/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenXR.Loader" version="1.0.10" targetFramework="native" />
+  <package id="OpenXR.Headers" version="1.0.10.1" targetFramework="native" />
 </packages>

--- a/shared/XrSceneLib/XrSceneLib_uwp.vcxproj
+++ b/shared/XrSceneLib/XrSceneLib_uwp.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -166,14 +166,13 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" />
+    <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props'))" />
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets'))" />
   </Target>
 </Project>
-

--- a/shared/XrSceneLib/XrSceneLib_win32.vcxproj
+++ b/shared/XrSceneLib/XrSceneLib_win32.vcxproj
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" />
+  <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" />
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|ARM">
       <Configuration>Debug</Configuration>
@@ -159,13 +159,13 @@
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
   <ImportGroup Label="ExtensionTargets">
-    <Import Project="..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets" Condition="Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" />
+    <Import Project="..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets" Condition="Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" />
   </ImportGroup>
   <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
     <PropertyGroup>
       <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
     </PropertyGroup>
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.props'))" />
-    <Error Condition="!Exists('..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Loader.1.0.10\build\native\OpenXR.Loader.targets'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.props'))" />
+    <Error Condition="!Exists('..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\..\packages\OpenXR.Headers.1.0.10.1\build\native\OpenXR.Headers.targets'))" />
   </Target>
 </Project>

--- a/shared/XrSceneLib/packages.config
+++ b/shared/XrSceneLib/packages.config
@@ -1,4 +1,4 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="OpenXR.Loader" version="1.0.10" targetFramework="native" />
+  <package id="OpenXR.Headers" version="1.0.10.1" targetFramework="native" />
 </packages>


### PR DESCRIPTION
This new version of the NuGet packages provide two changes:
1. Headers are moved into a separate NuGet package to avoid redundant loader DLLs getting packaged when using multiple projects.
2. A fix for a file system change in the 1.0.10 loader that introduced a regression for UWP apps.