### PR TITLE
Add ability to use extension dispatch table when missing extensions

### DIFF
--- a/shared/XrUtility/XrExtensions.h
+++ b/shared/XrUtility/XrExtensions.h
@@ -22,6 +22,13 @@
 #define FOR_EACH_WIN32_EXTENSION_FUNCTION(_)
 #endif
 
+#ifdef XR_USE_GRAPHICS_API_D3D11
+#define FOR_EACH_D3D11_EXTENSION_FUNCTION(_) \
+    _(xrGetD3D11GraphicsRequirementsKHR)
+#else
+#define FOR_EACH_D3D11_EXTENSION_FUNCTION(_)
+#endif
+
 #ifdef XR_MSFT_CONTROLLER_MODEL_PREVIEW_EXTENSION_NAME
 #define FOR_EACH_CONTROLLER_MODEL_EXTENSION_FUNCTION(_) \
     _(xrGetControllerModelKeyMSFT)               \
@@ -42,9 +49,9 @@
     _(xrCreateHandMeshSpaceMSFT)                    \
     _(xrUpdateHandMeshMSFT)                         \
     _(xrCreateSpatialGraphNodeSpaceMSFT)            \
-    _(xrGetD3D11GraphicsRequirementsKHR)            \
     _(xrGetVisibilityMaskKHR)                       \
     FOR_EACH_WIN32_EXTENSION_FUNCTION(_)            \
+    FOR_EACH_D3D11_EXTENSION_FUNCTION(_)            \
     FOR_EACH_CONTROLLER_MODEL_EXTENSION_FUNCTION(_)
 
 #define GET_INSTANCE_PROC_ADDRESS(name) \

--- a/shared/XrUtility/XrExtensions.h
+++ b/shared/XrUtility/XrExtensions.h
@@ -15,23 +15,37 @@
 //*********************************************************
 #pragma once
 
-#define FOR_EACH_EXTENSION_FUNCTION(_)           \
-    _(xrCreateSpatialAnchorMSFT)                 \
-    _(xrCreateSpatialAnchorSpaceMSFT)            \
-    _(xrDestroySpatialAnchorMSFT)                \
-    _(xrCreateHandTrackerEXT)                    \
-    _(xrDestroyHandTrackerEXT)                   \
-    _(xrLocateHandJointsEXT)                     \
-    _(xrCreateHandMeshSpaceMSFT)                 \
-    _(xrUpdateHandMeshMSFT)                      \
-    _(xrConvertWin32PerformanceCounterToTimeKHR) \
-    _(xrCreateSpatialGraphNodeSpaceMSFT)         \
-    _(xrGetD3D11GraphicsRequirementsKHR)         \
+#ifdef XR_USE_PLATFORM_WIN32
+#define FOR_EACH_WIN32_EXTENSION_FUNCTION(_) \
+    _(xrConvertWin32PerformanceCounterToTimeKHR)
+#else
+#define FOR_EACH_WIN32_EXTENSION_FUNCTION(_)
+#endif
+
+#ifdef XR_MSFT_CONTROLLER_MODEL_PREVIEW_EXTENSION_NAME
+#define FOR_EACH_CONTROLLER_MODEL_EXTENSION_FUNCTION(_) \
     _(xrGetControllerModelKeyMSFT)               \
     _(xrLoadControllerModelMSFT)                 \
     _(xrGetControllerModelPropertiesMSFT)        \
-    _(xrGetControllerModelStateMSFT)             \
-    _(xrGetVisibilityMaskKHR)
+    _(xrGetControllerModelStateMSFT)
+#else
+#define FOR_EACH_CONTROLLER_MODEL_EXTENSION_FUNCTION(_)
+#endif
+
+#define FOR_EACH_EXTENSION_FUNCTION(_)              \
+    _(xrCreateSpatialAnchorMSFT)                    \
+    _(xrCreateSpatialAnchorSpaceMSFT)               \
+    _(xrDestroySpatialAnchorMSFT)                   \
+    _(xrCreateHandTrackerEXT)                       \
+    _(xrDestroyHandTrackerEXT)                      \
+    _(xrLocateHandJointsEXT)                        \
+    _(xrCreateHandMeshSpaceMSFT)                    \
+    _(xrUpdateHandMeshMSFT)                         \
+    _(xrCreateSpatialGraphNodeSpaceMSFT)            \
+    _(xrGetD3D11GraphicsRequirementsKHR)            \
+    _(xrGetVisibilityMaskKHR)                       \
+    FOR_EACH_WIN32_EXTENSION_FUNCTION(_)            \
+    FOR_EACH_CONTROLLER_MODEL_EXTENSION_FUNCTION(_)
 
 #define GET_INSTANCE_PROC_ADDRESS(name) \
     (void)xrGetInstanceProcAddr(instance, #name, reinterpret_cast<PFN_xrVoidFunction*>(const_cast<PFN_##name*>(&name)));


### PR DESCRIPTION
We are looking to use the XrUtility files in a project referencing the OpenXR-SDK repo as a submodule. Some extensions aren't present when referencing OpenXR-SDK compared to this project. This change allows developers to use the extension dispatch table defined in the XrUtility codebase when preview extensions/win32 extensions aren't present.

I've tested building this when neither win32/previews are present, when only win32 is present and when both win32 and preview extensions are present. I'm not sure if there is a way to test instances when win32 isn't present but preview extensions are?