### PR TITLE
Bring Bryce's fix for recent build break due to VS 16.7.1 upgrade.

### DIFF
--- a/Directory.Build.targets
+++ b/Directory.Build.targets
@@ -2,7 +2,7 @@
 
     <ItemDefinitionGroup>
         <ClCompile>
-            <AdditionalIncludeDirectories>$(OpenXrSdkPath)\include;$(SharedPath);$(SharedPath)\ext;$(IntDir)\CompiledShaders;%(AdditionalIncludeDirectories);</AdditionalIncludeDirectories>
+            <AdditionalIncludeDirectories>$(OpenXrSdkPath)\include;$(SharedPath);$(SharedPath)\ext;$(IntDir);%(AdditionalIncludeDirectories);</AdditionalIncludeDirectories>
         </ClCompile>
     </ItemDefinitionGroup>
 

--- a/shared/gltf/Gltf_uwp.vcxproj
+++ b/shared/gltf/Gltf_uwp.vcxproj
@@ -92,7 +92,7 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup>
-    <IncludePath>..;..\ext;$(IntDir)\CompiledShaders;$(IncludePath);</IncludePath>
+    <IncludePath>..;..\ext;$(IncludePath);</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>

--- a/shared/gltf/Gltf_win32.vcxproj
+++ b/shared/gltf/Gltf_win32.vcxproj
@@ -114,7 +114,7 @@
     <WindowsSDKDesktopARM64Support>true</WindowsSDKDesktopARM64Support>
   </PropertyGroup>
   <PropertyGroup>
-    <IncludePath>..;..\ext;$(IntDir)\CompiledShaders;$(IncludePath);</IncludePath>
+    <IncludePath>..;..\ext;$(IncludePath);</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/shared/pbr/pbr_uwp.vcxproj
+++ b/shared/pbr/pbr_uwp.vcxproj
@@ -159,7 +159,7 @@
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <PropertyGroup>
-    <IncludePath>..;..\ext;$(IntDir)\CompiledShaders;$(IncludePath);</IncludePath>
+    <IncludePath>..;..\ext;$(IntDir);$(IncludePath);</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
@@ -375,14 +375,14 @@
       <FileType>Document</FileType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\CompiledShaders\%(Filename).h</HeaderFileOutput>
+      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\%(Filename).h</HeaderFileOutput>
       <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
     </None>
     <None Include="Shaders\PbrShared.hlsl">
       <FileType>Document</FileType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\CompiledShaders\%(Filename).h</HeaderFileOutput>
+      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\%(Filename).h</HeaderFileOutput>
       <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
     </None>
     <FxCompile Include="Shaders\PbrPixelShader.hlsl">
@@ -392,7 +392,7 @@
       <VariableName>g_psPbrMain</VariableName>
       <EnableDebuggingInformation>true</EnableDebuggingInformation>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput>$(IntDir)\CompiledShaders\%(Filename).h</HeaderFileOutput>
+      <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
       <ObjectFileOutput />
     </FxCompile>
     <FxCompile Include="Shaders\PbrVertexShader.hlsl">
@@ -403,28 +403,28 @@
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
       <ObjectFileOutput />
-      <HeaderFileOutput>$(IntDir)\CompiledShaders\%(Filename).h</HeaderFileOutput>
+      <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
       <DeploymentContent />
     </FxCompile>
     <None Include="Shaders\HighlightShared.hlsl">
       <FileType>Document</FileType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\CompiledShaders\%(Filename).h</HeaderFileOutput>
+      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\%(Filename).h</HeaderFileOutput>
       <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
     </None>
     <FxCompile Include="Shaders\HighlightPixelShader.hlsl">
       <ShaderType>Pixel</ShaderType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput>$(IntDir)\CompiledShaders\%(Filename).h</HeaderFileOutput>
+      <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
       <ObjectFileOutput />
     </FxCompile>
     <FxCompile Include="Shaders\HighlightVertexShader.hlsl">
       <ShaderType>Vertex</ShaderType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput>$(IntDir)\CompiledShaders\%(Filename).h</HeaderFileOutput>
+      <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
       <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
       </ObjectFileOutput>
     </FxCompile>

--- a/shared/pbr/pbr_uwp.vcxproj
+++ b/shared/pbr/pbr_uwp.vcxproj
@@ -375,15 +375,15 @@
       <FileType>Document</FileType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\%(Filename).h</HeaderFileOutput>
-      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+      <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
+      <ObjectFileOutput />
     </None>
     <None Include="Shaders\PbrShared.hlsl">
       <FileType>Document</FileType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\%(Filename).h</HeaderFileOutput>
-      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+      <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
+      <ObjectFileOutput />
     </None>
     <FxCompile Include="Shaders\PbrPixelShader.hlsl">
       <FileType>Document</FileType>
@@ -398,7 +398,6 @@
     <FxCompile Include="Shaders\PbrVertexShader.hlsl">
       <FileType>Document</FileType>
       <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
       <ShaderType>Vertex</ShaderType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
@@ -410,8 +409,8 @@
       <FileType>Document</FileType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\%(Filename).h</HeaderFileOutput>
-      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+      <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
+      <ObjectFileOutput />
     </None>
     <FxCompile Include="Shaders\HighlightPixelShader.hlsl">
       <ShaderType>Pixel</ShaderType>
@@ -425,8 +424,7 @@
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
       <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
-      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
-      </ObjectFileOutput>
+      <ObjectFileOutput />
     </FxCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/shared/pbr/pbr_win32.vcxproj
+++ b/shared/pbr/pbr_win32.vcxproj
@@ -351,15 +351,15 @@
       <FileType>Document</FileType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\%(Filename).h</HeaderFileOutput>
-      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+      <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
+      <ObjectFileOutput />
     </None>
     <None Include="Shaders\PbrShared.hlsl">
       <FileType>Document</FileType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\%(Filename).h</HeaderFileOutput>
-      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+      <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
+      <ObjectFileOutput />
     </None>
     <FxCompile Include="Shaders\PbrPixelShader.hlsl">
       <FileType>Document</FileType>
@@ -374,7 +374,6 @@
     <FxCompile Include="Shaders\PbrVertexShader.hlsl">
       <FileType>Document</FileType>
       <DeploymentContent>false</DeploymentContent>
-      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
       <ShaderType>Vertex</ShaderType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
@@ -386,8 +385,8 @@
       <FileType>Document</FileType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\%(Filename).h</HeaderFileOutput>
-      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+      <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
+      <ObjectFileOutput />
     </None>
     <FxCompile Include="Shaders\HighlightPixelShader.hlsl">
       <ShaderType>Pixel</ShaderType>
@@ -401,8 +400,7 @@
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
       <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
-      <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
-      </ObjectFileOutput>
+      <ObjectFileOutput />
     </FxCompile>
   </ItemGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />

--- a/shared/pbr/pbr_win32.vcxproj
+++ b/shared/pbr/pbr_win32.vcxproj
@@ -132,7 +132,7 @@
   <PropertyGroup>
   </PropertyGroup>
   <PropertyGroup>
-    <IncludePath>..;..\ext;$(IntDir)\CompiledShaders;$(IncludePath);</IncludePath>
+    <IncludePath>..;..\ext;$(IntDir);$(IncludePath);</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <LinkIncremental>true</LinkIncremental>
@@ -351,14 +351,14 @@
       <FileType>Document</FileType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\CompiledShaders\%(Filename).h</HeaderFileOutput>
+      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\%(Filename).h</HeaderFileOutput>
       <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
     </None>
     <None Include="Shaders\PbrShared.hlsl">
       <FileType>Document</FileType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\CompiledShaders\%(Filename).h</HeaderFileOutput>
+      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\%(Filename).h</HeaderFileOutput>
       <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
     </None>
     <FxCompile Include="Shaders\PbrPixelShader.hlsl">
@@ -368,7 +368,7 @@
       <VariableName>g_psPbrMain</VariableName>
       <EnableDebuggingInformation>true</EnableDebuggingInformation>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput>$(IntDir)\CompiledShaders\%(Filename).h</HeaderFileOutput>
+      <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
       <ObjectFileOutput />
     </FxCompile>
     <FxCompile Include="Shaders\PbrVertexShader.hlsl">
@@ -379,28 +379,28 @@
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
       <ObjectFileOutput />
-      <HeaderFileOutput>$(IntDir)\CompiledShaders\%(Filename).h</HeaderFileOutput>
+      <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
       <DeploymentContent />
     </FxCompile>
     <None Include="Shaders\HighlightShared.hlsl">
       <FileType>Document</FileType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\CompiledShaders\%(Filename).h</HeaderFileOutput>
+      <HeaderFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">$(IntDir)\%(Filename).h</HeaderFileOutput>
       <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
     </None>
     <FxCompile Include="Shaders\HighlightPixelShader.hlsl">
       <ShaderType>Pixel</ShaderType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput>$(IntDir)\CompiledShaders\%(Filename).h</HeaderFileOutput>
+      <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
       <ObjectFileOutput />
     </FxCompile>
     <FxCompile Include="Shaders\HighlightVertexShader.hlsl">
       <ShaderType>Vertex</ShaderType>
       <ShaderModel>5.0</ShaderModel>
       <VariableName>g_%(Filename)</VariableName>
-      <HeaderFileOutput>$(IntDir)\CompiledShaders\%(Filename).h</HeaderFileOutput>
+      <HeaderFileOutput>$(IntDir)\%(Filename).h</HeaderFileOutput>
       <ObjectFileOutput Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
       </ObjectFileOutput>
     </FxCompile>


### PR DESCRIPTION
CompiledShaders folder is no longer created after VS 16.7.1 upgrade.  Change build settings to output shader headers to IntDir directly.