### PR TITLE
Fix header warning

### DIFF
--- a/shared/XrUtility/XrSceneUnderstanding.h
+++ b/shared/XrUtility/XrSceneUnderstanding.h
@@ -45,7 +45,7 @@ namespace xr {
         computeInfo.bounds.frustums = bounds.frustumBounds.data();
         computeInfo.bounds.sphereCount = static_cast<uint32_t>(bounds.sphereBounds.size());
         computeInfo.bounds.spheres = bounds.sphereBounds.data();
-        computeInfo.disableInferredSceneObjects = false;
+        computeInfo.disableInferredSceneObjects = disableInferredSceneObjects;
         CHECK_XRCMD(extensions.xrComputeNewSceneMSFT(sceneObserver, &computeInfo));
     }
 


### PR DESCRIPTION
disableInferredSceneObjects isn't used which generates a warning. This can cause errors in consuming libs/binaries that treat warnings as errors