### PR TITLE
Fix failed assert in XrMath.h

### DIFF
--- a/shared/XrUtility/XrMath.h
+++ b/shared/XrUtility/XrMath.h
@@ -53,9 +53,11 @@ namespace xr::math {
         NearFar NearFar;
     };
 
-    // Type conversion between math types
+    // Type conversion between math types.
+    // If you get the error "attempting to reference a deleted function" then you need to implement
+    // xr::math::detail::implement_math_cast for types X and Y. See examples further down.
     template <typename X, typename Y>
-    constexpr const X& cast(const Y& value);
+    constexpr const X& cast(const Y& value) = delete;
 
     // Convert XR types to DX
     DirectX::XMVECTOR XM_CALLCONV LoadXrVector2(const XrVector2f& vector);
@@ -104,13 +106,6 @@ namespace xr::math {
             return reinterpret_cast<X&>(value);
         }
     } // namespace detail
-
-#ifdef _MSC_VER
-    template <typename X, typename Y>
-    constexpr const X& cast(const Y& value) {
-        static_assert(false, "Undefined cast from Y to type X");
-    }
-#endif
 
 #define DEFINE_CAST(X, Y)                             \
     template <>                                       \


### PR DESCRIPTION
Fixed issue #109. The error occurred in VS2022 but not in the VS2019 toolset.

The compiler error message isn't as obvious now but I added a comment if anyone tries to use xr::math::cast for a type that hasn't added a template specialization.